### PR TITLE
real_escape_string... format added to redirect files

### DIFF
--- a/MS3/README
+++ b/MS3/README
@@ -30,6 +30,7 @@ the login credentials below.
 To be used with connection.php
 
 
+
 3. CHANGELOG FOR DATABASE SCRIPT:
 -Added user table to hold user/password credentials
 -Divided main Application table into 3 tables, one for each page,

--- a/MS3/login_redirect.php
+++ b/MS3/login_redirect.php
@@ -8,7 +8,7 @@ $_SESSION['user_id'] = $_POST['user_id'];
 // check login credentials
 $loginIsValid = FALSE;
 
-$user = $_POST['user_id'];
+$user = mysqli_real_escape_string($conn, $_POST['user_id']);
 $pwd = $_POST['user_password'];
 $sql = "SELECT * FROM user WHERE user_id = '$user' and user_password = md5('$pwd')";
 $result = mysqli_query($conn, $sql);

--- a/MS3/view_redirect.php
+++ b/MS3/view_redirect.php
@@ -8,7 +8,7 @@ $_SESSION['user_id'] = $_POST['user_id'];
 // check login credentials
 $loginIsValid = FALSE;
 
-$user = $_POST['user_id'];
+$user = mysqli_real_escape_string($conn, $_POST['user_id']);
 $pwd = $_POST['user_password'];
 $sql = "SELECT * FROM user WHERE user_id = '$user' and user_password = md5('$pwd')";
 $result = mysqli_query($conn, $sql);


### PR DESCRIPTION
README not intentionally - probaly left different amount of blank spaces when I deleted my credentials (shouldn't hurt anything)

redirect files have real_escape_string
